### PR TITLE
Troubleshooting

### DIFF
--- a/JWTGuard/JWTGuard.csproj
+++ b/JWTGuard/JWTGuard.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TheApi.Tests\TheApi.Tests.csproj" />
     <ProjectReference Include="..\TheApi\TheApi.csproj" />
   </ItemGroup>
 

--- a/JWTGuard/TestSettings.cs
+++ b/JWTGuard/TestSettings.cs
@@ -19,12 +19,11 @@ public readonly struct TestSettings
         {
             TargetUrl = "/api/test",
             DefaultAudience = "https://localhost:7000",
-            DefaultIssuer = "dotnet-user-jwts",
             AllowedAudiences = ["https://localhost:7000", "http://localhost:5000"],
-            AllowedAlgorithms = [SecurityAlgorithms.RsaSha256],
-            ValidTokenTypes = ["jwt"],
+            DefaultIssuer = "dotnet-user-jwts",
+            AllowedIssuers = [ "dotnet-user-jwts" ],
             InvalidTokenTypes = ["none"],
-            AllowedIssuers = ["dotnet-user-jwts"],
+            
             // AssertAuthorizedResponse = response => Assert.Equal(StatusCodes.Status204NoContent, (int)response.StatusCode)
         };
     }

--- a/JWTGuard/TestSettings.cs
+++ b/JWTGuard/TestSettings.cs
@@ -138,6 +138,11 @@ public readonly struct TestSettings
     public string DefaultIssuer { get; init; } = "https://localhost:5901";
 
     /// <summary>
+    /// The default endpoint for Duende IdentityServer. Defaults to "https://localhost:5901".
+    /// </summary>
+    public string DuendeHostAddress { get; init; } = "https://localhost:5901";
+    
+    /// <summary>
     /// Collection of allowed issuers. Defaults to [ "https://localhost:5901" ].
     /// </summary>
     public IReadOnlyCollection<string> AllowedIssuers { get; init; } = ["https://localhost:5901"];

--- a/JWTGuard/TestSettings.cs
+++ b/JWTGuard/TestSettings.cs
@@ -22,6 +22,11 @@ public readonly struct TestSettings
             AllowedAudiences = ["https://localhost:7000", "http://localhost:5000"],
             DefaultIssuer = "dotnet-user-jwts",
             AllowedIssuers = [ "dotnet-user-jwts" ],
+            
+            DefaultSignatureAlgorithm = SecurityAlgorithms.HmacSha256, // to use dotnet-user-jwts
+            AllowedAlgorithms = [ SecurityAlgorithms.HmacSha256 ],
+            DisallowedAlgorithms = KnownSecurityAlgorithms.Except([SecurityAlgorithms.HmacSha256]).ToArray(),
+            
             ValidTokenTypes = ["JWT"],
             InvalidTokenTypes = ["none"],
             

--- a/JWTGuard/TestSettings.cs
+++ b/JWTGuard/TestSettings.cs
@@ -22,6 +22,7 @@ public readonly struct TestSettings
             AllowedAudiences = ["https://localhost:7000", "http://localhost:5000"],
             DefaultIssuer = "dotnet-user-jwts",
             AllowedIssuers = [ "dotnet-user-jwts" ],
+            ValidTokenTypes = ["JWT"],
             InvalidTokenTypes = ["none"],
             
             // AssertAuthorizedResponse = response => Assert.Equal(StatusCodes.Status204NoContent, (int)response.StatusCode)

--- a/JWTGuard/Tests/ExternalSignatureTests.cs
+++ b/JWTGuard/Tests/ExternalSignatureTests.cs
@@ -15,7 +15,12 @@ namespace JWTGuard.Tests;
 /// </summary>
 public class ExternalSignatureTests(TargetApiWebApplicationFactory factory) : JwtGuardTestBase(factory)
 {
-    [Fact(DisplayName = "When using an external JSON Web Key by specifying the 'jku' and 'kid' claims in the token, the API should return a 401 Unauthorized response.")]
+    private const string SkipBecauseOfSymmetricAlgorithm =
+        "When only allowing a symmetric algorithm, the external key material test can't be run. The key material generator needs to have a least one asymmetric algorithm configured.";
+    
+    [Fact(
+        DisplayName = "When using an external JSON Web Key by specifying the 'jku' and 'kid' claims in the token, the API should return a 401 Unauthorized response.",
+        Skip = SkipBecauseOfSymmetricAlgorithm)]
     internal async Task Accessing_AuthorizedUrl_Is_Unauthorized_For_External_WebKey_Using_jku_Claim()
     {
         // Arrange
@@ -29,7 +34,9 @@ public class ExternalSignatureTests(TargetApiWebApplicationFactory factory) : Jw
         TestSettings.CurrentTestSettings.AssertUnauthorizedResponse(response);
     }
 
-    [Fact(DisplayName = "When using an external JSON Web Key by specifying the 'jwk' claim in the token, the API should return a 401 Unauthorized response.")]
+    [Fact(
+        DisplayName = "When using an external JSON Web Key by specifying the 'jwk' claim in the token, the API should return a 401 Unauthorized response.",
+        Skip = SkipBecauseOfSymmetricAlgorithm)]
     internal async Task Accessing_AuthorizedUrl_Is_Unauthorized_For_External_WebKey_Using_jwk_Claim()
     {
         // Arrange
@@ -43,7 +50,9 @@ public class ExternalSignatureTests(TargetApiWebApplicationFactory factory) : Jw
         TestSettings.CurrentTestSettings.AssertUnauthorizedResponse(response);
     }
 
-    [Fact(DisplayName = "When using an external certificate by specifying the 'x5u' claim in the token, the API should return a 401 Unauthorized response.")]
+    [Fact(
+        DisplayName = "When using an external certificate by specifying the 'x5u' claim in the token, the API should return a 401 Unauthorized response.",
+        Skip = SkipBecauseOfSymmetricAlgorithm)]
     internal async Task Accessing_AuthorizedUrl_Is_Unauthorized_For_External_Certificate_Using_x5u_Claim()
     {
         // Arrange
@@ -57,7 +66,9 @@ public class ExternalSignatureTests(TargetApiWebApplicationFactory factory) : Jw
         TestSettings.CurrentTestSettings.AssertUnauthorizedResponse(response);
     }
 
-    [Fact(DisplayName = "When using an external certificate by specifying the 'x5c' claim in the token, the API should return a 401 Unauthorized response.")]
+    [Fact(
+        DisplayName = "When using an external certificate by specifying the 'x5c' claim in the token, the API should return a 401 Unauthorized response.",
+        Skip = SkipBecauseOfSymmetricAlgorithm)]
     internal async Task Accessing_AuthorizedUrl_Is_Unauthorized_For_External_Certificate_Using_x5c_Claim()
     {
         // Arrange

--- a/JWTGuard/Tests/JwtGuardTestBase.cs
+++ b/JWTGuard/Tests/JwtGuardTestBase.cs
@@ -1,9 +1,7 @@
 using JWTGuard.Helpers;
 
 using Microsoft.AspNetCore.Mvc.Testing;
-using TheApi.Tests.Fixtures;
 using Xunit;
-using static Duende.IdentityServer.Models.IdentityResources;
 
 namespace JWTGuard.Tests;
 
@@ -35,14 +33,9 @@ public abstract class JwtGuardTestBase(TargetApiWebApplicationFactory factory) :
     /// <summary>
     /// Initializes the base class for a test run.
     /// </summary>
-    public async Task InitializeAsync()
+    public Task InitializeAsync()
     {
         Environment.SetEnvironmentVariable("AppSettings__UseDevJwt", "true");
-
-        // Have to get a JWT to turn on dev certs for this project
-        (string jwt, string error) = await TestJwtBuilder.GetTestJwt("jon@doe.com", []);
-        ArgumentNullException.ThrowIfNullOrWhiteSpace(jwt, nameof(jwt));
-        Assert.Equal("", error);
 
         Client = Factory.CreateClient(new WebApplicationFactoryClientOptions
         {
@@ -52,6 +45,7 @@ public abstract class JwtGuardTestBase(TargetApiWebApplicationFactory factory) :
         _serviceScope = Factory.Services.CreateAsyncScope();
         ServiceProvider = _serviceScope.ServiceProvider;
         
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/JWTGuard/Tests/SignatureAlgorithmTests.cs
+++ b/JWTGuard/Tests/SignatureAlgorithmTests.cs
@@ -56,9 +56,19 @@ public class SignatureAlgorithmTests(TargetApiWebApplicationFactory factory) : J
 
     private Task<string> GetJwtAsync(string signatureAlgorithm)
     {
-        return Factory.CreateJwtBuilder()
-            .WithSignatureAlgorithm(signatureAlgorithm)
-            .BuildAsync();
+        var builder = Factory.CreateJwtBuilder();
+
+        if (signatureAlgorithm == "HS256")
+        {
+            // this forces JwtBuilder to use the secret from dotnet-user-jwts
+            builder.WithSignatureAlgorithm(signatureAlgorithm, "");
+        }
+        else
+        {
+            builder.WithSignatureAlgorithm(signatureAlgorithm);
+        }
+        
+        return builder.BuildAsync();
     }
 
     /// <summary>

--- a/TheApi/Helpers/JwtAuthenticationFailedLogger.cs
+++ b/TheApi/Helpers/JwtAuthenticationFailedLogger.cs
@@ -2,25 +2,26 @@ namespace TheApi.Helpers;
 
 public static class JwtAuthenticationFailedLogger
 {
-    public static async Task WriteAuthenticationFailed(AuthenticationFailedContext context)
+    public static Task WriteAuthenticationFailed(AuthenticationFailedContext context)
     {
-        ILogger logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Program>>();
-
-        logger.LogError($"Authentication failed for {context.Principal?.Identity?.Name} to {context.Request.Path}: {context.Exception.Message}");
-        ApiResponse res = new ApiResponse
-        {
-            Success = false,
-            Message = "401: Authentication failed"
-        };
-        try
-        {
-            context.Response.StatusCode = 401;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, $"Failed to set status code to 401 when athentication failed for {context.Principal?.Identity?.Name} to {context.Request.Path}: {ex.Message}");
-            // Don't fail trying to error
-        }
-        await context.Response.WriteAsJsonAsync(res);
+        return Task.CompletedTask;
+        // ILogger logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Program>>();
+        //
+        // logger.LogError($"Authentication failed for {context.Principal?.Identity?.Name} to {context.Request.Path}: {context.Exception.Message}");
+        // ApiResponse res = new ApiResponse
+        // {
+        //     Success = false,
+        //     Message = "401: Authentication failed"
+        // };
+        // try
+        // {
+        //     context.Response.StatusCode = 401;
+        // }
+        // catch (Exception ex)
+        // {
+        //     logger.LogError(ex, $"Failed to set status code to 401 when athentication failed for {context.Principal?.Identity?.Name} to {context.Request.Path}: {ex.Message}");
+        //     // Don't fail trying to error
+        // }
+        // await context.Response.WriteAsJsonAsync(res);
     }
 }

--- a/TheApi/appsettings.Development.json
+++ b/TheApi/appsettings.Development.json
@@ -13,5 +13,16 @@
   },
   "ConnectionStrings": {
     "TheDB": "USE USER SECRETS"
+  },
+  "Authentication": {
+    "Schemes": {
+      "Bearer": {
+        "ValidAudiences": [
+          "https://localhost:7000",
+          "http://localhost:5000"
+        ],
+        "ValidIssuer": "dotnet-user-jwts"
+      }
+    }
   }
 }


### PR DESCRIPTION
I believe I found the main culprits:
- JwtAuthenticationFailedLogger was writing to the HTTP response too early, causing the tests to fail when the JWT Bearer middleware wanted to set its status code.
- The test settings needed some tweaking to only allow "JWT" (token type is case-sensitive) and the HS256 algorithm. I've also changed the JwtBuilder code and one test to ensure that it uses the secret generated by dotnet-user-jwts
- I had to disable the external signature tests, since these need at least one asymmetrical algorithm to be allowed in order to generate key material. But if you're only allowing a symmetric algorithm and you don't load the external key material as the secret, you're good.
- In the Program.cs of the API project, I added some lines to ensure that the allowed security algorithms match the use case (HS256 when using dotnet-user-jwts, RS256 when using Entra ID/Azure B2C)